### PR TITLE
Add Swinject-based service locator

### DIFF
--- a/Models/Country.swift
+++ b/Models/Country.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct Country: Identifiable, Codable {
+    let id = UUID()
+    let flag: String
+    let name: String
+    let continent: String
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Wayfinder",
+    platforms: [
+        .iOS(.v17)
+    ],
+    products: [
+        .library(name: "Wayfinder", targets: ["Wayfinder"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Swinject/Swinject.git", from: "2.8.0")
+    ],
+    targets: [
+        .target(
+            name: "Wayfinder",
+            dependencies: ["Swinject"],
+            path: ".",
+            exclude: ["agents.md", "README.md"],
+            sources: ["Models", "Services", "Utilities", "ViewModels", "Views", "WayfinderApp.swift"]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# codex-ios
+# Wayfinder
+
+## Development
+
+Dependencies are managed using Swift Package Manager. The project relies on
+[Swinject](https://github.com/Swinject/Swinject) for dependency injection. Run
+`swift build` to resolve packages.

--- a/Services/CountryService.swift
+++ b/Services/CountryService.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+protocol CountryServiceProtocol {
+    func fetchCountries() -> [Country]
+}
+
+struct MockCountryService: CountryServiceProtocol {
+    func fetchCountries() -> [Country] {
+        return [
+            Country(flag: "🇺🇸", name: "United States", continent: "North America"),
+            Country(flag: "🇫🇷", name: "France", continent: "Europe"),
+            Country(flag: "🇯🇵", name: "Japan", continent: "Asia"),
+            Country(flag: "🇧🇷", name: "Brazil", continent: "South America")
+        ]
+    }
+}

--- a/Utilities/ServiceLocator.swift
+++ b/Utilities/ServiceLocator.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Swinject
+
+final class ServiceLocator {
+    static let shared = ServiceLocator()
+    private let container = Container()
+
+    private init() {}
+
+    func addService<T>(_ service: T) {
+        container.register(T.self) { _ in service }
+            .inObjectScope(.container)
+    }
+
+    func getService<T>() -> T {
+        guard let service = container.resolve(T.self) else {
+            fatalError("No registered service for type \(T.self)")
+        }
+        return service
+    }
+}

--- a/ViewModels/CountryListViewModel.swift
+++ b/ViewModels/CountryListViewModel.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Observation
+
+@Observable
+final class CountryListViewModel {
+    var countries: [Country] = []
+
+    private let countryService: CountryServiceProtocol
+
+    init(countryService: CountryServiceProtocol = ServiceLocator.shared.getService()) {
+        self.countryService = countryService
+        loadCountries()
+    }
+
+    func loadCountries() {
+        countries = countryService.fetchCountries()
+    }
+}

--- a/Views/CountryListView.swift
+++ b/Views/CountryListView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+import Observation
+
+struct CountryListView: View {
+    @Bindable var viewModel: CountryListViewModel
+
+    var body: some View {
+        NavigationView {
+            List(viewModel.countries) { country in
+                HStack {
+                    Text(country.flag)
+                    VStack(alignment: .leading) {
+                        Text(country.name)
+                        Text(country.continent)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Countries")
+        }
+    }
+}
+
+#Preview {
+    CountryListView(viewModel: CountryListViewModel())
+}

--- a/WayfinderApp.swift
+++ b/WayfinderApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct WayfinderApp: App {
+    init() {
+        ServiceLocator.shared.addService(MockCountryService() as CountryServiceProtocol)
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            CountryListView(viewModel: CountryListViewModel())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- use Swinject for dependency injection via `ServiceLocator`
- manage dependencies via SPM in a new `Package.swift`
- document SPM and Swinject usage in README

## Testing
- `swift build` *(fails: CONNECT tunnel failed)*
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6857b94c4a688320b2841671951ab8ea